### PR TITLE
Add aria-hidden attribute to created spans, aria-label attribute to p…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = function (element, options) {
   options = options || {}
+  element.normalize()
 
   var tagName = options.tagName || 'span'
   var classPrefix = options.classPrefix != null ? options.classPrefix : 'char'
@@ -17,7 +18,11 @@ module.exports = function (element, options) {
         count++
       }
       node.appendChild(document.createTextNode(string[i]))
+      node.setAttribute('aria-hidden', 'true')
       parentNode.insertBefore(node, element)
+    }
+    if (string.trim() !== '') {
+      parentNode.setAttribute('aria-label', string)
     }
     parentNode.removeChild(element)
   }

--- a/test.js
+++ b/test.js
@@ -9,20 +9,22 @@ function createElement (innerHTML) {
 }
 
 test('should not inject spans when `elem` has no child nodes', function (t) {
-  t.plan(1)
+  t.plan(2)
   const elem = createElement()
   charming(elem)
   t.equal(elem.innerHTML, '')
+  t.equal(elem.getAttribute('aria-label'), null)
 })
 
 test('should not inject spans when `elem` has no child text nodes', function (
   t
 ) {
-  t.plan(1)
+  t.plan(2)
   const innerHTML = '<span></span>'
   const elem = createElement(innerHTML)
   charming(elem)
   t.equal(elem.innerHTML, innerHTML)
+  t.equal(elem.getAttribute('aria-label'), null)
 })
 
 test('should inject spans when `elem` has a single child text node', function (

--- a/test.js
+++ b/test.js
@@ -69,7 +69,6 @@ test('can inject custom tags', function (t) {
 test('can inject spans without classes', function (t) {
   t.plan(2)
   const elem = createElement('foo')
-  
   charming(elem, {
     classPrefix: false
   })

--- a/test.js
+++ b/test.js
@@ -28,58 +28,64 @@ test('should not inject spans when `elem` has no child text nodes', function (
 test('should inject spans when `elem` has a single child text node', function (
   t
 ) {
-  t.plan(1)
+  t.plan(2)
   const elem = createElement('foo')
   charming(elem)
+  t.equal(elem.getAttribute('aria-label'), 'foo')
   t.equal(
     elem.innerHTML,
-    '<span class="char1">f</span><span class="char2">o</span><span class="char3">o</span>'
+    '<span class="char1" aria-hidden="true">f</span><span class="char2" aria-hidden="true">o</span><span class="char3" aria-hidden="true">o</span>'
   )
 })
 
 test('should inject spans when `elem` has multiple child text nodes', function (
   t
 ) {
-  t.plan(1)
+  t.plan(2)
   const elem = createElement(
     '<span>foo</span> <span>bar <span>baz</span></span>'
   )
   charming(elem)
+  t.equal(elem.getAttribute('aria-label'), null)
   t.equal(
     elem.innerHTML,
-    '<span><span class="char1">f</span><span class="char2">o</span><span class="char3">o</span></span><span class="char4"> </span><span><span class="char5">b</span><span class="char6">a</span><span class="char7">r</span><span class="char8"> </span><span><span class="char9">b</span><span class="char10">a</span><span class="char11">z</span></span></span>'
+    '<span aria-label="foo"><span class="char1" aria-hidden="true">f</span><span class="char2" aria-hidden="true">o</span><span class="char3" aria-hidden="true">o</span></span><span class="char4" aria-hidden="true"> </span><span aria-label="bar "><span class="char5" aria-hidden="true">b</span><span class="char6" aria-hidden="true">a</span><span class="char7" aria-hidden="true">r</span><span class="char8" aria-hidden="true"> </span><span aria-label="baz"><span class="char9" aria-hidden="true">b</span><span class="char10" aria-hidden="true">a</span><span class="char11" aria-hidden="true">z</span></span></span>'
   )
 })
 
 test('can inject custom tags', function (t) {
-  t.plan(1)
+  t.plan(2)
   const elem = createElement('foo')
   charming(elem, {
     tagName: 'b'
   })
+  t.equal(elem.getAttribute('aria-label'), 'foo')
   t.equal(
     elem.innerHTML,
-    '<b class="char1">f</b><b class="char2">o</b><b class="char3">o</b>'
+    '<b class="char1" aria-hidden="true">f</b><b class="char2" aria-hidden="true">o</b><b class="char3" aria-hidden="true">o</b>'
   )
 })
 
 test('can inject spans without classes', function (t) {
-  t.plan(1)
+  t.plan(2)
   const elem = createElement('foo')
+  
   charming(elem, {
     classPrefix: false
   })
-  t.equal(elem.innerHTML, '<span>f</span><span>o</span><span>o</span>')
+  t.equal(elem.getAttribute('aria-label'), 'foo')
+  t.equal(elem.innerHTML, '<span aria-hidden="true">f</span><span aria-hidden="true">o</span><span aria-hidden="true">o</span>')
 })
 
 test('can inject spans with a custom class prefix', function (t) {
-  t.plan(1)
+  t.plan(2)
   const elem = createElement('foo')
   charming(elem, {
     classPrefix: 'c'
   })
+  t.equal(elem.getAttribute('aria-label'), 'foo')
   t.equal(
     elem.innerHTML,
-    '<span class="c1">f</span><span class="c2">o</span><span class="c3">o</span>'
+    '<span class="c1" aria-hidden="true">f</span><span class="c2" aria-hidden="true">o</span><span class="c3" aria-hidden="true">o</span>'
   )
 })


### PR DESCRIPTION
This adds ARIA attributes to elements processed by charming in a way that mirrors Lettering.js. These attributes help screen readers--otherwise, a div run through charming with text 'foo' might be read by a screen reader as the individual letters 'F-O-O'.

Refs on these attributes: [aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute), [aria-hidden](https://www.w3.org/TR/wai-aria-1.1/#aria-hidden)

I didn't write tests specifically for this since the existing ones could be adapted to make sure they were doing sensible things with the ARIA attributes.